### PR TITLE
apply a prefix to all uniqid calls

### DIFF
--- a/src/lib/scrollEvent/index.js
+++ b/src/lib/scrollEvent/index.js
@@ -32,7 +32,7 @@ export default (ReactTable) => {
     constructor(props) {
       super(props);
       const hasGroups = !!props.columns.find(column => column.columns);
-      this.tableDataId = `data-table-${uniqid()}`;
+      this.tableDataId = `data-table-${uniqid('rthfc-')}`;
       const fixedColumnsWithoutGroup = props.columns.filter(column => column.fixed && !column.columns).map(({ Header }) => `'${Header}'`);
       if (hasGroups && fixedColumnsWithoutGroup.length) {
         console.warn([
@@ -41,8 +41,8 @@ export default (ReactTable) => {
         ].join('\n\n'));
       }
 
-      this.fixedLeftClassName = uniqid();
-      this.fixedRightClassName = uniqid();
+      this.fixedLeftClassName = uniqid('rthfc-');
+      this.fixedRightClassName = uniqid('rthfc-');
 
       this.onChangePropertyList = {
         onResizedChange: this.onChangeProperty('onResizedChange'),

--- a/src/lib/stickyPosition/index.js
+++ b/src/lib/stickyPosition/index.js
@@ -48,7 +48,7 @@ export default (ReactTable) => {
 
       this.tableClassName = getTableClassName(this.props);
       this.columnsWidth = {};
-      this.uniqClassName = uniqid();
+      this.uniqClassName = uniqid('rthfc-');
     }
 
     componentDidMount() {


### PR DESCRIPTION
Closes #11.

On some systems, since `uniqid` uses a mac address as part of the hash, the leading character can be a digit which is not a valid selector in CSS.

![screen shot 2018-09-13 at 1 01 01 pm](https://user-images.githubusercontent.com/836375/45519533-51b47f00-b76a-11e8-8d7a-c581f51c339e.png)
