### PR TITLE
Transform NodeList to Array by Array.from

### DIFF
--- a/src/lib/scrollEvent/index.js
+++ b/src/lib/scrollEvent/index.js
@@ -86,11 +86,11 @@ export default (ReactTable) => {
 
     updatePos(target = this.tableRef) {
       /* eslint-disable no-param-reassign */
-      target.querySelectorAll(`.${this.fixedLeftClassName}`).forEach((td) => {
+      Array.from(target.querySelectorAll(`.${this.fixedLeftClassName}`)).forEach((td) => {
         td.style.transform = `translate3d(${this.nextTranslateLeftX}px, 0, 0)`;
       });
 
-      target.querySelectorAll(`.${this.fixedRightClassName}`).forEach((td) => {
+      Array.from(target.querySelectorAll(`.${this.fixedRightClassName}`)).forEach((td) => {
         td.style.transform = `translate3d(${-this.nextTranslateRightX}px, 0, 0)`;
       });
       /* eslint-enable no-param-reassign */


### PR DESCRIPTION
[Since IE doesn't support `forEach` on NodeList](https://developer.mozilla.org/sv-SE/docs/Web/API/NodeList/forEach) the error "Object doesn't support property or method 'forEach'" was always shown and the table didn't render.