### PR TITLE
Fix right offset for multiple right fixed columns

### DIFF
--- a/src/lib/stickyPosition/index.js
+++ b/src/lib/stickyPosition/index.js
@@ -87,7 +87,7 @@ export default (ReactTable) => {
 
     getRightOffsetColumns(columns, index) {
       let offset = 0;
-      for (let i = index + 1; i < columns.length - index; i += 1) {
+      for (let i = index + 1; i < columns.length; i += 1) {
         const column = columns[i];
         const id = getColumnId(column);
         const width = this.columnsWidth[id] || column.width || column.minWidth || 100;


### PR DESCRIPTION
When having more than one fixed right column, the right offset for each column was always set to 0, because of a bug in the columns loop. This caused only one column to appear as fixed.