### PR TITLE
Adding position:-webkit-sticky for Safari support

### DIFF
--- a/src/lib/styles.css
+++ b/src/lib/styles.css
@@ -43,6 +43,7 @@
 }
 
 .rthfc.-sp .rt-thead {
+  position: -webkit-sticky;
   position: sticky;
 }
 
@@ -51,6 +52,7 @@
 }
 
 .rthfc.-sp .rt-tfoot {
+  position: -webkit-sticky;
   position: sticky;
   z-index: 1;
   bottom: 0px;
@@ -58,6 +60,7 @@
 
 .rthfc.-sp .rthfc-th-fixed,
 .rthfc.-sp .rthfc-td-fixed {
+  position: -webkit-sticky;
   position: sticky;
   z-index: 1;
 }


### PR DESCRIPTION
Position sticky being fully supported on Safari / iOS safary only through the use of `position: -webkit-sticky;`, can be useful to use the prefixed version as well 👍

Reference : https://caniuse.com/#feat=css-sticky