### PR TITLE
[FIX re-render] - remove memo from getColumns and allow re-render

### DIFF
--- a/src/lib/stickyPosition/index.js
+++ b/src/lib/stickyPosition/index.js
@@ -161,11 +161,14 @@ export default (ReactTable) => {
       });
     }
 
-    getColumns = memoize((columns) => {
-      const sortedColumns = sortColumns(columns);
+    getSorted = memoize(columns => sortColumns(columns))
+
+    getColumns = (columns) => {
+      const sortedColumns = this.getSorted(columns);
+
       const columnsWithFixed = this.getColumnsWithFixed(sortedColumns);
       return columnsWithFixed;
-    })
+    }
 
     render() {
       const {


### PR DESCRIPTION
Due to memo from getColumns, this.forceUpdate() will not trigger re-render at onResizedChange 